### PR TITLE
Switch to GitHub Container Registry for Docker images

### DIFF
--- a/.github/workflows/on-trunk-merge.yml
+++ b/.github/workflows/on-trunk-merge.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      GH_DOCKER_USERNAME: ${{ secrets.GH_DOCKER_USERNAME }}
+      GH_DOCKER_TOKEN: ${{ secrets.GH_DOCKER_TOKEN }}
       FORCE_COLOR: 1
     steps:
       - uses: earthly/actions-setup@v1
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Docker Login
-        run: docker login --username "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_TOKEN"
+        run: docker login ghcr.io --username "$GH_DOCKER_USERNAME" --password "$GH_DOCKER_TOKEN"
 
       - name: Run build
         run: earthly --ci --push +build-all-images

--- a/.github/workflows/on-trunk-merge.yml
+++ b/.github/workflows/on-trunk-merge.yml
@@ -1,10 +1,11 @@
 # .github/workflows/ci.yml
 
-name: Earthly +build
+name: On Merge MAIN
 
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/Earthfile
+++ b/Earthfile
@@ -85,7 +85,7 @@ build-image-api:
      FROM --platform=$TARGETPLATFORM alpine:3.20
     COPY (+build-api/api --VARIANT=$TARGETVARIANT) ./app
     ENTRYPOINT ["/app"]
-    SAVE IMAGE --push autoscaler/api:latest
+    SAVE IMAGE --push ghcr.io/autoscalerhq/api:latest
 
 build-image-worker:
     ARG TARGETPLATFORM
@@ -96,5 +96,5 @@ build-image-worker:
         --platform=linux/amd64 \
         (+build-worker/worker --VARIANT=$TARGETVARIANT) ./app
     ENTRYPOINT ["/app"]
-    SAVE IMAGE --push autoscaler/worker:latest
+    SAVE IMAGE --push ghcr.io/autoscalerhq/worker:latest
 


### PR DESCRIPTION
Updated the Earthfile to push images to ghcr.io instead of DockerHub. Adjusted GitHub Actions workflow to use GitHub Container Registry credentials for authentication.

### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pulls request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
